### PR TITLE
Add global site hits counter

### DIFF
--- a/.docs/specs/2026-06-22--global-site-hits/README.md
+++ b/.docs/specs/2026-06-22--global-site-hits/README.md
@@ -2,12 +2,12 @@
 
 | Field            | Value                                   |
 | ---------------- | --------------------------------------- |
-| **Status**       | draft                                   |
+| **Status**       | in-progress                             |
 | **Owner**        | @hta218                                 |
 | **Issue**        | N/A                                     |
 | **Branch**       | `feat/global-site-hits`                 |
 | **Created**      | 2026-06-22                              |
-| **Last Updated** | 2026-06-22                              |
+| **Last Updated** | 2026-06-23                              |
 
 ## Original Prompt
 

--- a/.docs/specs/2026-06-22--global-site-hits/migration.sql
+++ b/.docs/specs/2026-06-22--global-site-hits/migration.sql
@@ -1,0 +1,15 @@
+-- Global site hits counter — run once in the Supabase SQL editor.
+-- Idempotent: re-running never resets a live count.
+
+create table if not exists site_counters (
+  key   text primary key,
+  value bigint not null default 0
+);
+
+-- Seed the global hits counter from existing accumulated post + snippet views.
+insert into site_counters (key, value)
+values ('hits', (select coalesce(sum(views), 0) from stats))
+on conflict (key) do nothing;
+
+-- Sanity check
+-- select * from site_counters where key = 'hits';

--- a/src/components/widgets/SiteHits.tsx
+++ b/src/components/widgets/SiteHits.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react'
+import { fetchSiteHits } from '~/lib/stats'
+
+/**
+ * Displays the site-wide global hit count for the home page "views" card. Read-only — the
+ * actual increment happens once per page load in `BaseLayout.astro`. Like `ViewsCounter`, it
+ * shows a neutral `—` fallback when the `/api/hits.json` endpoint can't answer (static build,
+ * missing `DATABASE_URL`) and never fakes a number.
+ */
+export default function SiteHits() {
+  const [hits, setHits] = useState<number | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    fetchSiteHits().then((value) => {
+      if (cancelled || value === null) return
+      setHits(value)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return <>{hits === null ? '—' : hits.toLocaleString()}</>
+}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -26,12 +26,12 @@ const {
 } = Astro.props
 
 const pageTitle = title ? `${title} — ${SITE.author}` : SITE.title
-const canonical =
-  canonicalUrl ?? new URL(Astro.url.pathname, SITE.siteUrl).href
+const canonical = canonicalUrl ?? new URL(Astro.url.pathname, SITE.siteUrl).href
 const image = new URL(ogImage ?? SITE.socialBanner, SITE.siteUrl).href
 const rssTitle = `${SITE.title} RSS feed`
-const umamiWebsiteId =
-  (import.meta.env.PUBLIC_UMAMI_WEBSITE_ID || process.env.PUBLIC_UMAMI_WEBSITE_ID)?.trim()
+const umamiWebsiteId = (
+  import.meta.env.PUBLIC_UMAMI_WEBSITE_ID || process.env.PUBLIC_UMAMI_WEBSITE_ID
+)?.trim()
 ---
 
 <!doctype html>
@@ -100,5 +100,14 @@ const umamiWebsiteId =
   </head>
   <body>
     <slot />
+    <script>
+      // Site-wide global hit counter. Counts every page load: the initial load and each SPA
+      // navigation both fire `astro:page-load`, so reload = 1 hit. Fire-and-forget against
+      // `/api/hits.json`; failures are silent. It's a vanity counter, not analytics — no
+      // throttle/dedup, since the JS-gated increment already skips non-JS crawlers.
+      import { incrementSiteHits } from '~/lib/stats'
+
+      document.addEventListener('astro:page-load', incrementSiteHits)
+    </script>
   </body>
 </html>

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -13,6 +13,7 @@
 import type { BlogStats, StatsType } from '~/types/stats'
 
 const STATS_ENDPOINT = '/api/stats'
+const HITS_ENDPOINT = '/api/hits.json'
 
 export function emptyStats(type: StatsType, slug: string): BlogStats {
   return {
@@ -74,5 +75,27 @@ export async function postStats(
     return res.ok
   } catch {
     return false
+  }
+}
+
+/** Read the site-wide global hit count. Returns `null` when the endpoint is unavailable. */
+export async function fetchSiteHits(): Promise<number | null> {
+  try {
+    const res = await fetch(HITS_ENDPOINT)
+    if (!res.ok) return null
+    const data = (await res.json()) as { ok?: boolean; hits?: number }
+    if (!data.ok || typeof data.hits !== 'number') return null
+    return data.hits
+  } catch {
+    return null
+  }
+}
+
+/** Increment the site-wide hit count (fire-and-forget). Errors are swallowed. */
+export async function incrementSiteHits(): Promise<void> {
+  try {
+    await fetch(HITS_ENDPOINT, { method: 'POST', keepalive: true })
+  } catch {
+    // ignore — vanity counter, never block or surface failures
   }
 }

--- a/src/pages/api/hits.json.ts
+++ b/src/pages/api/hits.json.ts
@@ -1,0 +1,72 @@
+import type { APIRoute } from 'astro'
+import { getSql } from '~/lib/db'
+
+/**
+ * Site-wide global hit counter, backed by a single `site_counters` row (`key = 'hits'`).
+ *
+ * - GET  → `{ ok, hits }`, lazily seeding the row from `SUM(stats.views)` if it's missing.
+ * - POST → increments and returns the new total (also seeds on first hit via `on conflict`).
+ *
+ * Mirrors `api/stats.ts`: `prerender = false`, shared `getSql()` pool, try/catch → 503, and
+ * graceful failure when `DATABASE_URL` is absent (plain `astro preview`). The home page card
+ * falls back to `—` rather than faking a number when this endpoint can't answer.
+ *
+ * Seed query is idempotent: `insert … on conflict (key) do nothing/update` never resets a
+ * live count, so re-running the migration or hitting a fresh deploy is safe.
+ */
+
+const HITS_KEY = 'hits'
+
+const JSON_HEADERS = {
+  // Approximate vanity counter — a short shared cache is fine and spares the DB.
+  'cache-control': 'public, max-age=0, s-maxage=30',
+  'content-type': 'application/json; charset=utf-8',
+}
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: JSON_HEADERS })
+}
+
+export const prerender = false
+
+export const GET: APIRoute = async () => {
+  try {
+    const db = getSql()
+
+    // Lazily seed from accumulated post + snippet views the first time it's read.
+    await db`
+      insert into site_counters (key, value)
+      values (${HITS_KEY}, (select coalesce(sum(views), 0) from stats))
+      on conflict (key) do nothing
+    `
+
+    const [row] = await db<{ value: number }[]>`
+      select value from site_counters where key = ${HITS_KEY} limit 1
+    `
+
+    return json({ ok: true, hits: Number(row?.value ?? 0) })
+  } catch (error) {
+    console.error('[api/hits]', error)
+    return json({ ok: false, hits: 0 }, 503)
+  }
+}
+
+export const POST: APIRoute = async () => {
+  try {
+    const db = getSql()
+
+    // Seed-and-increment in one statement: the first ever hit also establishes the
+    // baseline from existing post views, so order of deploy vs. migration doesn't matter.
+    const [row] = await db<{ value: number }[]>`
+      insert into site_counters (key, value)
+      values (${HITS_KEY}, (select coalesce(sum(views), 0) from stats) + 1)
+      on conflict (key) do update set value = site_counters.value + 1
+      returning value
+    `
+
+    return json({ ok: true, hits: Number(row?.value ?? 0) })
+  } catch (error) {
+    console.error('[api/hits]', error)
+    return json({ ok: false, hits: 0 }, 503)
+  }
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,9 +1,10 @@
 ---
 import { getCollection } from 'astro:content'
+import HugeIcon from '~/components/icons/HugeIcon.astro'
 import Twemoji from '~/components/mdx/Twemoji.astro'
 import CodeBlock from '~/components/studio/CodeBlock.astro'
 import StudioShell from '~/components/studio/StudioShell.astro'
-import HugeIcon from '~/components/icons/HugeIcon.astro'
+import SiteHits from '~/components/widgets/SiteHits'
 import BaseLayout from '~/layouts/BaseLayout.astro'
 
 const isPublished = (d: { data: { draft?: boolean } }) => d.data.draft !== true
@@ -17,8 +18,18 @@ const latest = posts.slice(0, 3)
 const exploreCards = [
   { href: '/gists', label: 'gists/', desc: 'reusable code bits', icon: 'code' },
   { href: '/builds', label: 'builds/', desc: 'things I built', icon: 'folder' },
-  { href: '/shelf#reading', label: 'shelf/reading', desc: 'what I read', icon: 'book' },
-  { href: '/shelf#watching', label: 'shelf/watching', desc: 'what I watch', icon: 'file' },
+  {
+    href: '/shelf#reading',
+    label: 'shelf/reading',
+    desc: 'what I read',
+    icon: 'book',
+  },
+  {
+    href: '/shelf#watching',
+    label: 'shelf/watching',
+    desc: 'what I watch',
+    icon: 'file',
+  },
 ] as const
 
 const dateFmt = new Intl.DateTimeFormat('en-CA') // YYYY-MM-DD
@@ -66,10 +77,10 @@ const dateFmt = new Intl.DateTimeFormat('en-CA') // YYYY-MM-DD
         </div>
         <div class="rounded-2xl border border-line bg-white p-3">
           <div class="flex items-center justify-between">
-            <b class="block text-[28px]">—</b>
+            <b class="block text-[28px]"><SiteHits client:idle /></b>
             <HugeIcon name="analytics" class="text-slate-400" />
           </div>
-          <span class="font-mono text-[11px] text-muted">views</span>
+          <span class="font-mono text-[11px] text-muted">hits</span>
         </div>
       </div>
     </div>

--- a/src/types/stats.ts
+++ b/src/types/stats.ts
@@ -19,3 +19,8 @@ export interface BlogStats {
   ideas: number
   bullseyes: number
 }
+
+/** Site-wide global hit counter (see `/api/hits.json`). */
+export interface SiteHits {
+  hits: number
+}


### PR DESCRIPTION
## Summary

Adds a real, site-wide **global hits** counter to replace the hardcoded `—` placeholder in the home page stat card (now labelled **hits**).

- New `/api/hits.json` endpoint backed by a single `site_counters` row, **seeded from `SUM(stats.views)`** (existing post + snippet views) so it starts at a meaningful number instead of zero.
  - `GET` reads the count (lazily seeds the row if missing).
  - `POST` increments (seed-and-increment in one statement). Degrades gracefully (503 / `—`) when the DB is unavailable.
- `SiteHits` React island displays the live count on the home card.
- `BaseLayout` increments the counter on every `astro:page-load` — **reload = 1 hit**, including SPA navigations. No throttle/dedup (vanity counter; the JS-gated increment already skips non-JS crawlers).
- Adds `SiteHits` type and `fetchSiteHits` / `incrementSiteHits` client helpers.

## Database

The `site_counters` migration has **already been run** against Supabase (seeded at **57,464** = `SUM(stats.views)`). SQL is committed at `.docs/specs/2026-06-22--global-site-hits/migration.sql` for reference / other environments:

```sql
create table if not exists site_counters (
  key   text primary key,
  value bigint not null default 0
);
insert into site_counters (key, value)
values ('hits', (select coalesce(sum(views), 0) from stats))
on conflict (key) do nothing;
```

## Notes

- Independent of Umami analytics — this is a vanity counter, not analytics.
- On plain `astro preview` (no Vercel Functions) the card falls back to `—`; needs a runtime (dev server / Vercel) to show the real number.

Spec: `.docs/specs/2026-06-22--global-site-hits/`