### PR TITLE
Restore canonical blog URLs

### DIFF
--- a/.docs/specs/2026-06-18--route-rebrand/README.md
+++ b/.docs/specs/2026-06-18--route-rebrand/README.md
@@ -2,12 +2,12 @@
 
 | Field            | Value                          |
 | ---------------- | ------------------------------ |
-| **Status**       | done                      |
+| **Status**       | reopened — blog URL canonical rollback |
 | **Owner**        | @hta218                         |
 | **Issue**        | N/A                            |
 | **Branch**       | `feat/route-rebrand`           |
 | **Created**      | 2026-06-18                      |
-| **Last Updated** | 2026-06-18                      |
+| **Last Updated** | 2026-07-08                      |
 
 ## Original Prompt
 
@@ -16,16 +16,23 @@
 > I'd like you to review the routing of this new version. I don't want the
 > old-style routes (`/blog`, `/snippets`, `/projects`, …). Got any ideas?
 >
-> (after review) Decisions: `/about → /whoami`; `/blog → /log`;
+> (after review) Initial decisions: `/about → /whoami`; `/blog → /log`;
 > `/snippets → /gists`; `/projects → /builds`; merge `/books` + `/movies`
 > into `/shelf`; `/tags → /topics`.
+>
+> 2026-07-08 SEO rollback decision: restore the public/canonical blog URL
+> pattern to `/blog` while keeping the dev-flavored UI label `logs` / `Log`.
 
 ## Summary
 
-Rebrand v4's top-level routes to fit the "code workspace" identity, replacing the
-generic blog-style paths with developer/terminal-flavored ones. Post/snippet
-**slugs are preserved**; only section prefixes change, and every old path gets a
-301 redirect so existing SEO and deep links keep working. The home page stays the
-workspace `README`. `/books` and `/movies` merge into a single `/shelf`.
+Rebrand v4's top-level routes to fit the "code workspace" identity, replacing
+most generic paths with developer/terminal-flavored ones. The exception is blog
+content: after SEO review, `/blog` stays the canonical public URL pattern while
+the UI can still call the section `logs` / `Log`. Post/snippet **slugs are
+preserved**, and every non-canonical path gets a 301 redirect so existing SEO and
+deep links keep working. The home page stays the workspace `README`. `/books`
+and `/movies` merge into a single `/shelf`.
 
 See `plan.md` for the full route map, redirects, touched files, and rollout.
+For the 2026-07-08 implementation handoff, see
+`handoff--2026-07-08--restore-blog-url-canonical.md`.

--- a/.docs/specs/2026-06-18--route-rebrand/handoff--2026-07-08--restore-blog-url-canonical.md
+++ b/.docs/specs/2026-06-18--route-rebrand/handoff--2026-07-08--restore-blog-url-canonical.md
@@ -1,0 +1,197 @@
+# Handoff — Restore canonical blog URL pattern
+
+Date: 2026-07-08
+Owner: @hta218
+Repo: `/Users/hta218/Documents/personal/code/leohuynh.dev`
+Branch: `main`
+Base commit at handoff time: `5f54996`
+
+## Goal
+
+Restore blog content URLs back to the legacy/canonical `/blog` pattern for SEO stability, while keeping the developer-flavored UI labels where desired.
+
+Canonical blog routes must be:
+
+- Blog index: `/blog`
+- Blog detail: `/blog/:slug`
+- Blog pagination: `/blog/page/:page` for page 2+
+- Page 1 canonical: `/blog` only; `/blog/page/1` should redirect to `/blog`
+
+The old v4-only `/log` routes must redirect permanently to `/blog` equivalents.
+
+## Product decision
+
+Keep the left sidebar/explorer vibe label as `logs` / `Logs` if desired. Only the public URL pattern must change back to `/blog`.
+
+So this is OK:
+
+- Sidebar folder text: `logs`
+- Page title/nav label: `Log`
+- Internal route href/canonical/sitemap/RSS/search URL: `/blog...`
+
+## Current state found locally
+
+The current implementation routes blog content through `/log`:
+
+- `src/pages/log/index.astro`
+- `src/pages/log/[...slug].astro`
+- `src/pages/log/page/[page].astro`
+- `src/components/PostList.astro` links to `/log/${post.id}` and pagination uses `/log/page/${n}`
+- `src/pages/index.astro` latest writing links to `/log/${post.id}`
+- `src/pages/topics/[tag].astro` links blog entries to `/log/${post.id}`
+- `src/pages/feed.xml.ts` emits blog RSS links as `/log/${p.id}`
+- `src/pages/topics/[tag]/feed.xml.ts` emits blog links as `/log/${p.id}`
+- `src/pages/log/[...slug].astro` builds canonical/JSON-LD/Breadcrumb around `/log/${post.id}`
+- `src/components/studio/studio-shell/lib/explorer-tree.ts` uses `/log` hrefs and active matchers while showing `logs` label
+- `src/components/studio/studio-shell/lib/tabs.ts` resolves `/log` tabs
+- `src/lib/site.ts` `NAV_LINKS` uses `{ href: '/log', title: 'Log' }`
+- `astro.config.mjs` and `vercel.json` redirect `/blog*` to `/log*`
+- `search.json.ts` already emits `/blog/:id`; keep/fix as canonical `/blog`
+
+Existing content files in `data/blog/*.mdx` already contain legacy internal links such as `/blog/...`; these should become direct links again, not redirects.
+
+## Implementation requirements
+
+### 1. Restore route files
+
+Prefer `git mv` so history remains readable:
+
+- Move `src/pages/log/index.astro` → `src/pages/blog/index.astro`
+- Move `src/pages/log/[...slug].astro` → `src/pages/blog/[...slug].astro`
+- Move `src/pages/log/page/[page].astro` → `src/pages/blog/page/[page].astro`
+
+Remove the `/log` page routes after the redirect config is in place. Do not keep duplicate rendered pages at both `/log` and `/blog`; `/blog` is canonical, `/log` is redirect-only.
+
+### 2. Update canonical/internal URLs
+
+Update all blog route strings from `/log` to `/blog` where they represent public URLs:
+
+- `src/pages/blog/[...slug].astro`
+  - canonical fallback: `new URL(`/blog/${post.id}`, SITE.siteUrl).href`
+  - breadcrumb: `{ name: 'Log', url: `${SITE.siteUrl}/blog` }` is acceptable; label can remain `Log`
+  - `StudioShell active` should use `/blog/${post.id}`
+  - crumb may remain dev-flavored if desired, but avoid suggesting an actual `/log` URL if it is clearly a route crumb
+- `src/pages/blog/index.astro`
+  - route exists at `/blog`
+  - title can remain `Log`
+  - `StudioShell active` should use `/blog`
+- `src/pages/blog/page/[page].astro`
+  - route exists at `/blog/page/:page`
+  - page 1 remains omitted from static paths
+  - `StudioShell active` should use `/blog`
+- `src/components/PostList.astro`
+  - post hrefs `/blog/${post.id}`
+  - pagination: page 1 `/blog`, pages 2+ `/blog/page/${n}`
+- `src/pages/index.astro`
+  - latest writing links `/blog/${post.id}`
+- `src/pages/topics/[tag].astro`
+  - post links `/blog/${post.id}`
+- `src/pages/feed.xml.ts`
+  - blog item links `/blog/${p.id}`
+- `src/pages/topics/[tag]/feed.xml.ts`
+  - blog item links `/blog/${p.id}`
+- `src/lib/site.ts`
+  - `NAV_LINKS` blog/log entry should have `href: '/blog'`; title may stay `Log`
+- `src/pages/404.astro`
+  - “open blog” should href `/blog`
+- `src/components/studio/studio-shell/lib/explorer-tree.ts`
+  - visible folder `file: 'logs'`, `title: 'Logs'` may stay
+  - hrefs/activeWhen should match `/blog`
+  - `postsIndex.href = '/blog'`
+  - `postsSlug.href = latestPostId ? `/blog/${latestPostId}` : '/blog'`
+  - activeWhen uses `/blog` and `/blog/page/`
+- `src/components/studio/studio-shell/lib/tabs.ts`
+  - resolve `/blog`, `/blog/page/*`, `/blog/:slug`
+  - tab label/file can be `blog/index.astro` or remain visually `log/index.astro`; prefer `blog/index.astro` because route file is now under `src/pages/blog`
+- `src/pages/search.json.ts`
+  - keep blog document URL as `/blog/${entry.id}`; verify no regression
+
+Avoid changing `StatsType = 'blog'`; that is a data/content type, not URL prefix.
+
+### 3. Update redirects
+
+Update both `astro.config.mjs` and `vercel.json`.
+
+Remove the current `/blog -> /log` redirects.
+
+Add/keep these canonicalization redirects:
+
+- `/log` → `/blog`
+- `/log/page/1` → `/blog`
+- `/blog/page/1` → `/blog`
+- `/log/page/[page]` → `/blog/page/[page]` in `astro.config.mjs`
+- `/log/[...slug]` → `/blog/[...slug]` in `astro.config.mjs`
+- `/log/page/:page` → `/blog/page/:page` in `vercel.json`
+- `/log/:slug*` → `/blog/:slug*` in `vercel.json`
+
+Update special legacy redirect:
+
+- `/snippets/crawling-goodreads-books-data` → `/blog/crawling-goodreads-books-data`
+
+Keep unrelated route-rebrand redirects unchanged:
+
+- `/about` → `/whoami`
+- `/snippets*` → `/gists*`
+- `/projects` → `/builds`
+- `/books`, `/movies` → `/shelf`
+- `/tags*` → `/topics*`
+
+### 4. Stale text cleanup
+
+Search for stale `/log` public URL references after implementation:
+
+```bash
+rg "/log|`/log|\"/log|'\/log" src astro.config.mjs vercel.json .docs/specs/2026-06-18--route-rebrand
+```
+
+Expected allowed leftovers only if they are redirect sources or historical work-log/spec notes. In app source, `/log` should not remain as a public blog link/canonical/active route except redirect config if unavoidable.
+
+Do not rewrite unrelated words like `BuildLog`, movie title `Logan`, or generic “log” text.
+
+### 5. Verification
+
+Run these commands:
+
+```bash
+bun run check
+bun run build
+```
+
+Then verify built output and generated URLs:
+
+- `dist/client/blog/index.html` exists
+- Representative detail HTML exists for e.g. `dist/client/blog/does-promise-all-run-in-parallel-or-sequential/index.html` or equivalent generated path
+- `dist/client/sitemap-0.xml` contains `/blog` and `/blog/:slug` URLs
+- `dist/client/sitemap-0.xml` does not contain `/log` URLs
+- rendered canonical for a representative post is `https://www.leohuynh.dev/blog/<slug>`
+- main RSS `/feed.xml` emits blog links under `/blog/`
+- `/search.json` emits blog documents under `/blog/`
+
+If practical, run local preview and smoke test:
+
+```bash
+bun run preview -- --host 127.0.0.1 --port 4343
+```
+
+Smoke routes:
+
+- `GET /blog` → 200
+- `GET /blog/does-promise-all-run-in-parallel-or-sequential` → 200
+- `GET /blog/page/2` → 200, if enough posts
+- `GET /log` → permanent redirect to `/blog`
+- `GET /log/does-promise-all-run-in-parallel-or-sequential` → permanent redirect to `/blog/does-promise-all-run-in-parallel-or-sequential`
+- `GET /log/page/2` → permanent redirect to `/blog/page/2`
+- `GET /blog/page/1` → permanent redirect to `/blog`
+
+Note: plain `astro preview` may not emulate all Vercel redirects. If redirect behavior cannot be verified locally, verify source config and generated static routes, then say redirect runtime needs Vercel deployment smoke.
+
+## Acceptance criteria
+
+- `/blog` is the canonical blog index URL.
+- `/blog/:slug` is the canonical blog detail URL.
+- `/blog/page/:page` is the canonical pagination URL for page 2+.
+- `/log*` no longer renders duplicate content; it redirects permanently to `/blog*`.
+- Sitemap, canonical tags, Open Graph URLs, JSON-LD, RSS, search JSON, nav links, topic links, home latest links all use `/blog*`.
+- Sidebar folder label can remain `logs` / `Logs`.
+- `bun run check` and `bun run build` pass.
+- Do not commit or push; Hermes will verify first.

--- a/.docs/specs/2026-06-18--route-rebrand/plan.md
+++ b/.docs/specs/2026-06-18--route-rebrand/plan.md
@@ -6,6 +6,13 @@ Replace v4's generic routes with workspace/terminal-flavored ones, matching the
 "code studio" identity, **without breaking SEO or deep links**. Home stays the
 workspace README.
 
+2026-07-08 SEO rollback: keep the developer-flavored UI label for the writing
+section (`logs` / `Log`) but restore blog content's public/canonical URL pattern
+to the legacy `/blog` prefix. This avoids an unnecessary Google re-indexing
+migration for established blog URLs. See
+`handoff--2026-07-08--restore-blog-url-canonical.md` for the implementation
+scope.
+
 ## 2. Route map
 
 | Old route | New route | Notes |

--- a/.docs/specs/2026-06-18--route-rebrand/work-logs.md
+++ b/.docs/specs/2026-06-18--route-rebrand/work-logs.md
@@ -1,5 +1,37 @@
 # Work Logs
 
+## 2026-07-08 — blog URL canonical rollback
+
+Decision after SEO review: restore blog content URLs to the legacy `/blog` prefix,
+while keeping the visible dev-flavored section label as `logs` / `Log` where it
+fits the Studio shell vibe.
+
+- Wrote implementation handoff:
+  `handoff--2026-07-08--restore-blog-url-canonical.md`.
+- Required canonical routes: `/blog`, `/blog/:slug`, `/blog/page/:page` (page 2+).
+- Required redirects: `/log*` → `/blog*`; `/blog/page/1` → `/blog`.
+- Required SEO cleanup: sitemap, canonicals, OG URLs, JSON-LD, RSS, search JSON,
+  nav links, topic links, and home latest-post links all use `/blog*`.
+- Preserve sidebar folder label `logs` / `Logs` if desired; only public URL pattern
+  changes.
+- Delegated implementation to Claude Code from the handoff. Claude exited with
+  `Reached max turns (30)` but left a complete useful diff; Hermes inspected and
+  finished minor crumb/comment cleanup.
+- Verification completed by Hermes:
+  - `bun run check` — passed, `0 errors`, `0 warnings`, `0 hints`.
+  - `bun run build` — passed; generated `/blog/*` pages and redirect-only `/log*`
+    entries with empty response bodies.
+  - Static output checks — `/blog` index/detail exist; `/log` detail file absent;
+    representative canonical and OG URLs use `/blog`; sitemap/RSS/search JSON use
+    `/blog` and not `/log` for blog entries.
+  - Astro dev smoke — `/blog`, `/blog/:slug`, `/blog/page/2` return `200`;
+    `/log`, `/log/:slug`, `/log/page/2`, `/blog/page/1` return `301` to the
+    expected `/blog` destination.
+  - Browser spot check — representative post renders at `/blog/:slug`, canonical
+    and JSON-LD point to `/blog`, and console has no errors.
+- Autoreview Copilot was attempted but failed on Copilot NDJSON parse noise; manual
+  fallback used plus an independent no-edit review agent. No blockers found.
+
 ## 2026-06-18 — @hta218
 
 Implemented the route rebrand on `v4`.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -72,17 +72,17 @@ export default defineConfig({
   redirects: {
     '/snippets/crawling-goodreads-books-data': {
       status: 301,
-      destination: '/log/crawling-goodreads-books-data',
+      destination: '/blog/crawling-goodreads-books-data',
     },
     '/about': { status: 301, destination: '/whoami' },
-    '/blog': { status: 301, destination: '/log' },
-    // Page 1 duplicated `/log`'s own content — dropped, redirect any old links.
-    // Must precede `/blog/page/[page]` so it doesn't chain through
-    // `/log/page/1` first.
-    '/blog/page/1': { status: 301, destination: '/log' },
-    '/log/page/1': { status: 301, destination: '/log' },
-    '/blog/page/[page]': { status: 301, destination: '/log/page/[page]' },
-    '/blog/[...slug]': { status: 301, destination: '/log/[...slug]' },
+    // `/log*` is the old v4-only prefix — 301 back to the canonical `/blog*`.
+    // Page 1 must precede `/log/page/[page]` so it doesn't chain through
+    // `/blog/page/1` first.
+    '/log': { status: 301, destination: '/blog' },
+    '/log/page/1': { status: 301, destination: '/blog' },
+    '/blog/page/1': { status: 301, destination: '/blog' },
+    '/log/page/[page]': { status: 301, destination: '/blog/page/[page]' },
+    '/log/[...slug]': { status: 301, destination: '/blog/[...slug]' },
     '/snippets': { status: 301, destination: '/gists' },
     '/snippets/[...slug]': { status: 301, destination: '/gists/[...slug]' },
     '/projects': { status: 301, destination: '/builds' },

--- a/src/components/PostList.astro
+++ b/src/components/PostList.astro
@@ -12,7 +12,7 @@ const { posts, currentPage, totalPages } = Astro.props
 const dateFmt = new Intl.DateTimeFormat('en-CA') // YYYY-MM-DD
 
 // Page 1 lives at `/blog`; pages 2..N at `/blog/page/N` (legacy parity).
-const pageHref = (n: number) => (n <= 1 ? '/log' : `/log/page/${n}`)
+const pageHref = (n: number) => (n <= 1 ? '/blog' : `/blog/page/${n}`)
 const hasPrev = currentPage > 1
 const hasNext = currentPage < totalPages
 ---
@@ -21,7 +21,7 @@ const hasNext = currentPage < totalPages
   {
     posts.map((post) => (
       <a
-        href={`/log/${post.id}`}
+        href={`/blog/${post.id}`}
         class="grid grid-cols-1 items-start gap-4.5 border-t border-line py-4.5 no-underline first-of-type:border-t-0 md:grid-cols-[110px_1fr_auto]"
       >
         <time class="pt-1 font-mono text-xs text-muted">{dateFmt.format(post.data.date)}</time>

--- a/src/components/studio/studio-shell/lib/explorer-tree.ts
+++ b/src/components/studio/studio-shell/lib/explorer-tree.ts
@@ -25,21 +25,21 @@ export function buildExplorerTree(opts: {
   const postsIndex: TreeLeaf = {
     kind: 'leaf',
     id: 'posts-index',
-    href: '/log',
+    href: '/blog',
     file: 'index.astro',
     title: 'Posts index',
     icon: { type: 'brand', name: 'astro' },
-    activeWhen: (path) => path === '/log' || path.startsWith('/log/page/'),
+    activeWhen: (path) => path === '/blog' || path.startsWith('/blog/page/'),
   }
   const postsSlug: TreeLeaf = {
     kind: 'leaf',
     id: 'posts-slug',
-    href: opts.latestPostId ? `/log/${opts.latestPostId}` : '/log',
+    href: opts.latestPostId ? `/blog/${opts.latestPostId}` : '/blog',
     file: '[...slug].astro',
     title: 'Post detail template',
     icon: { type: 'brand', name: 'astro' },
     activeWhen: (path) =>
-      path.startsWith('/log/') && !path.startsWith('/log/page/'),
+      path.startsWith('/blog/') && !path.startsWith('/blog/page/'),
   }
   const snippetsIndex: TreeLeaf = {
     kind: 'leaf',
@@ -95,7 +95,7 @@ export function buildExplorerTree(opts: {
       title: 'Logs',
       icon: { type: 'huge', name: 'folder' },
       children: [postsIndex, postsSlug],
-      activeWhen: startsWith('/log'),
+      activeWhen: startsWith('/blog'),
     },
     {
       kind: 'folder',

--- a/src/components/studio/studio-shell/lib/tabs.ts
+++ b/src/components/studio/studio-shell/lib/tabs.ts
@@ -31,12 +31,12 @@ type TabContext = {
 export function resolveCurrentTab(path: string, ctx: TabContext): TreeLeaf {
   const { items, postsIndex, snippetsIndex, miscIndex } = ctx
 
-  if (path === '/log' || path.startsWith('/log/page/')) {
+  if (path === '/blog' || path.startsWith('/blog/page/')) {
     return {
       ...postsIndex,
       id: 'current',
-      href: '/log',
-      file: 'log/index.astro',
+      href: '/blog',
+      file: 'blog/index.astro',
     }
   }
   if (path === '/gists') {
@@ -47,8 +47,8 @@ export function resolveCurrentTab(path: string, ctx: TabContext): TreeLeaf {
       file: 'gists/index.astro',
     }
   }
-  if (path.startsWith('/log/')) {
-    const slug = decodeURIComponent(path.slice('/log/'.length))
+  if (path.startsWith('/blog/')) {
+    const slug = decodeURIComponent(path.slice('/blog/'.length))
     return {
       kind: 'leaf',
       id: 'current',

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -120,7 +120,7 @@ export const CAREER = [
 export const POSTS_PER_PAGE = 9
 
 export const NAV_LINKS = [
-  { href: '/log', title: 'Log' },
+  { href: '/blog', title: 'Log' },
   { href: '/gists', title: 'Gists' },
   { href: '/builds', title: 'Builds' },
   { href: '/whoami', title: 'whoami' },

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -15,7 +15,7 @@ import BaseLayout from '~/layouts/BaseLayout.astro'
       <p class="font-mono text-sm">
         <a href="/" class="text-code-blue no-underline">cd ~/</a>
         <span class="text-muted"> · </span>
-        <a href="/log" class="text-code-blue no-underline">open blog</a>
+        <a href="/blog" class="text-code-blue no-underline">open blog</a>
         <span class="text-muted"> · </span>
         <a href="/gists" class="text-code-blue no-underline">open snippets</a>
       </p>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -32,7 +32,7 @@ const dateFmt = new Intl.DateTimeFormat('en-US', {
 })
 const giscusConfig = getGiscusConfig()
 
-const canonical = canonicalUrl ?? new URL(`/log/${post.id}`, SITE.siteUrl).href
+const canonical = canonicalUrl ?? new URL(`/blog/${post.id}`, SITE.siteUrl).href
 const jsonLd = [
   articleJsonLd({
     title,
@@ -46,7 +46,7 @@ const jsonLd = [
   }),
   breadcrumbJsonLd([
     { name: 'Home', url: SITE.siteUrl },
-    { name: 'Log', url: `${SITE.siteUrl}/log` },
+    { name: 'Log', url: `${SITE.siteUrl}/blog` },
     { name: title, url: canonical },
   ]),
 ]
@@ -64,7 +64,7 @@ const jsonLd = [
   <Fragment slot="head">
     {jsonLd.map((data) => <JsonLd data={data} />)}
   </Fragment>
-  <StudioShell active={`/log/${post.id}`} crumb={`~/leohuynh.dev/log/${post.id}`}>
+  <StudioShell active={`/blog/${post.id}`} crumb={`~/leohuynh.dev/logs/${post.id}`}>
     <article class="prose">
       <h1>{title}</h1>
       <div class="mb-8 flex flex-wrap items-center gap-3 font-mono text-xs text-muted not-prose">

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -15,7 +15,7 @@ const display = posts.slice(0, POSTS_PER_PAGE)
   title="Log"
   description="Writing on web development, Shopify Hydrogen, TypeScript, and AI workflows."
 >
-  <StudioShell active="/log" crumb="~/leohuynh.dev/log">
+  <StudioShell active="/blog" crumb="~/leohuynh.dev/logs">
     <PageHeader
       title="Log"
       description="Writing on web development, Shopify Hydrogen, TypeScript, and AI workflows."

--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -6,7 +6,7 @@ import { getPublishedBlog } from '~/lib/content'
 import BaseLayout from '~/layouts/BaseLayout.astro'
 import { POSTS_PER_PAGE } from '~/lib/site'
 
-// Page 1 is `/log` itself (see `PostList`'s `pageHref`) — generating it here
+// Page 1 is `/blog` itself (see `PostList`'s `pageHref`) — generating it here
 // too would duplicate that page's content under a second URL, so pages start
 // at 2.
 export async function getStaticPaths() {
@@ -36,7 +36,7 @@ const { display, currentPage, totalPages, totalPosts } = Astro.props
   title={`Log — page ${currentPage}`}
   description="Writing on web development, Shopify Hydrogen, TypeScript, and AI workflows."
 >
-  <StudioShell active="/log" crumb={`~/leohuynh.dev/log/page/${currentPage}`}>
+  <StudioShell active="/blog" crumb={`~/leohuynh.dev/logs/page/${currentPage}`}>
     <PageHeader
       title="Log"
       description="Writing on web development, Shopify Hydrogen, TypeScript, and AI workflows."

--- a/src/pages/feed.xml.ts
+++ b/src/pages/feed.xml.ts
@@ -15,7 +15,7 @@ export async function GET(context: APIContext) {
   ])
 
   const items = [
-    ...posts.map((p) => ({ entry: p, link: `/log/${p.id}` })),
+    ...posts.map((p) => ({ entry: p, link: `/blog/${p.id}` })),
     ...snippets.map((s) => ({ entry: s, link: `/gists/${s.id}` })),
   ].sort((a, b) => b.entry.data.date.valueOf() - a.entry.data.date.valueOf())
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -84,7 +84,7 @@ const codebase = {
       {
         latest.map((post) => (
           <a
-            href={`/log/${post.id}`}
+            href={`/blog/${post.id}`}
             class="grid grid-cols-1 items-start gap-4.5 border-t border-line py-4.5 no-underline first-of-type:border-t-0 md:grid-cols-[92px_1fr_auto]"
           >
             <time class="font-mono text-xs text-muted">{dateFmt.format(post.data.date)}</time>

--- a/src/pages/search.json.ts
+++ b/src/pages/search.json.ts
@@ -14,7 +14,7 @@ export const GET: APIRoute = async () => {
     .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
     .map((entry) => {
       const kind = entry.collection === 'blog' ? 'blog' : 'snippet'
-      const url = `/${kind === 'blog' ? 'blog' : 'snippets'}/${entry.id}`
+      const url = `/${kind === 'blog' ? 'blog' : 'gists'}/${entry.id}`
       return {
         id: `${kind}:${entry.id}`,
         kind,

--- a/src/pages/topics/[tag].astro
+++ b/src/pages/topics/[tag].astro
@@ -57,7 +57,7 @@ const breadcrumb = breadcrumbJsonLd([
           <h3 class="mb-3 font-mono text-[11px] uppercase tracking-[0.08em] text-muted">posts</h3>
           {posts.map((post) => (
             <a
-              href={`/log/${post.id}`}
+              href={`/blog/${post.id}`}
               class="grid grid-cols-1 items-start gap-4.5 border-t border-line py-4.5 no-underline first-of-type:border-t-0 md:grid-cols-[110px_1fr]"
             >
               <time class="font-mono text-xs text-muted">{dateFmt.format(post.data.date)}</time>

--- a/src/pages/topics/[tag]/feed.xml.ts
+++ b/src/pages/topics/[tag]/feed.xml.ts
@@ -14,7 +14,7 @@ export async function GET(context: APIContext) {
   const { posts, snippets } = await getContentByTag(tag)
 
   const items = [
-    ...posts.map((p) => ({ entry: p, link: `/log/${p.id}` })),
+    ...posts.map((p) => ({ entry: p, link: `/blog/${p.id}` })),
     ...snippets.map((s) => ({ entry: s, link: `/gists/${s.id}` })),
   ].sort((a, b) => b.entry.data.date.valueOf() - a.entry.data.date.valueOf())
 

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
   "redirects": [
     {
       "source": "/snippets/crawling-goodreads-books-data",
-      "destination": "/log/crawling-goodreads-books-data",
+      "destination": "/blog/crawling-goodreads-books-data",
       "permanent": true
     },
     {
@@ -13,15 +13,17 @@
       "permanent": true
     },
     { "source": "/about", "destination": "/whoami", "permanent": true },
-    { "source": "/blog", "destination": "/log", "permanent": true },
+    { "source": "/log", "destination": "/blog", "permanent": true },
+    { "source": "/log/page/1", "destination": "/blog", "permanent": true },
+    { "source": "/blog/page/1", "destination": "/blog", "permanent": true },
     {
-      "source": "/blog/page/:page",
-      "destination": "/log/page/:page",
+      "source": "/log/page/:page",
+      "destination": "/blog/page/:page",
       "permanent": true
     },
     {
-      "source": "/blog/:slug*",
-      "destination": "/log/:slug*",
+      "source": "/log/:slug*",
+      "destination": "/blog/:slug*",
       "permanent": true
     },
     { "source": "/snippets", "destination": "/gists", "permanent": true },


### PR DESCRIPTION
Restore the historical `/blog` URL pattern for blog content to avoid unnecessary SEO/indexing churn.

- Make `/blog`, `/blog/:slug`, and `/blog/page/:page` canonical again; redirect `/log*` back to `/blog*`.
- Keep visible dev-flavored labels like `Log`/`logs`, but update hrefs, canonicals, feeds, sitemap, and search data to canonical URLs.
- Also fix search JSON snippet results to use canonical `/gists/:id` URLs.

Verification:
- `bun run check`
- `bun run build`
- Static output check for sitemap/RSS/search JSON/canonical URLs
- Local Astro dev smoke for `/blog*` 200 and `/log*` 301 redirects
