### PR TITLE
Add bilingual blog post support and git worktree article

### DIFF
--- a/.docs/specs/2026-07-15--bilingual-blog-posts/README.md
+++ b/.docs/specs/2026-07-15--bilingual-blog-posts/README.md
@@ -1,0 +1,20 @@
+# Feature: Bilingual Blog Posts
+
+| Field            | Value                            |
+| ---------------- | -------------------------------- |
+| **Status**       | completed                        |
+| **Owner**        | @hta218                          |
+| **Issue**        | N/A                              |
+| **Branch**       | `feat/bilingual-blog-posts`      |
+| **Created**      | 2026-07-15                       |
+| **Last Updated** | 2026-07-15                       |
+
+## Original Prompt
+
+> I find this really good and could share it on my blog. Write the full article out to a markdown file for me, then look at my blog (available locally) and see which section it should be moved into. I need both Vietnamese + English.
+>
+> (Follow-up decision: place both posts in `data/blog/` and port the bilingual support from the `misc` collection to the `blog` collection.)
+
+## Summary
+
+Ports the `lang`/`translationOf` bilingual pattern from the `misc` collection to the `blog` collection, so blog posts can ship in English (canonical) and Vietnamese (translation) with a language switcher and hreflang alternates. Ships the first bilingual pair: "Git worktree: one repo, many working directories" (EN + VI).

--- a/.docs/specs/2026-07-15--bilingual-blog-posts/plan.md
+++ b/.docs/specs/2026-07-15--bilingual-blog-posts/plan.md
@@ -1,0 +1,58 @@
+# Plan: Bilingual Blog Posts
+
+## Problem
+
+The `blog` collection had no language support — the `misc` collection already
+models bilingual content (`lang: 'en' | 'vi'` + `translationOf` pointing at the
+canonical entry), but blog posts were implicitly English-only. We want to
+publish a technical post (git worktree) in both English and Vietnamese under
+`/blog/<slug>`, without translations showing up as duplicate entries in lists.
+
+## Approach
+
+Mirror the proven `misc` pattern 1:1 onto the `blog` collection:
+
+- **Schema**: add `lang` (default `'en'`) and optional `translationOf` to the
+  blog collection. Existing posts need no frontmatter changes.
+- **Listing rule**: every list surface (blog index, pagination, home "latest",
+  studio sidebar latest-post link, RSS feed, tag counts, tag pages) shows only
+  primary posts (`translationOf` unset). Translations are reachable via the
+  language switcher on the detail page.
+- **Detail page**: build the translation group in `getStaticPaths`, render a
+  language switcher pill (same UI as misc), emit hreflang alternates
+  (`en`, `vi`, `x-default` → primary) and set `<html lang>` + JSON-LD
+  `inLanguage` from frontmatter.
+- **Search**: `search.json` keeps BOTH languages — search is a finder, not a
+  list, and titles differ per language.
+
+Shared helper `isPrimary()` lives in `src/lib/content.ts`.
+
+## Files Touched
+
+| File | Change |
+| --- | --- |
+| `src/content.config.ts` | `lang` + `translationOf` on blog schema |
+| `src/lib/content.ts` | `isPrimary()` helper; primaries-only tag counts & tag lists |
+| `src/pages/blog/index.astro` | filter primaries for list + count + pagination math |
+| `src/pages/blog/page/[page].astro` | filter primaries in `getStaticPaths` |
+| `src/pages/blog/[...slug].astro` | translations group, language switcher, hreflang, `lang`/`inLanguage` |
+| `src/pages/index.astro` | latest-3 posts from primaries only |
+| `src/components/studio/StudioShell.astro` | sidebar latest-post link from primaries only |
+| `src/pages/feed.xml.ts` | RSS blog items from primaries only |
+| `data/blog/git-worktree-one-repo-many-working-directories.mdx` | new post (EN, canonical) |
+| `data/blog/git-worktree-mot-repo-nhieu-thu-muc-lam-viec.mdx` | new post (VI, `translationOf` → EN slug) |
+
+## Verification
+
+- `bun run check` — 0 errors / 0 warnings.
+- `bun run build` — clean; inspected `dist/client`:
+  - both post pages generated; EN ↔ VI switcher links present on both
+  - hreflang `en`/`vi`/`x-default` emitted on both pages; VI page has `<html lang="vi">`
+  - blog index, home, `/topics/git`, and `feed.xml` contain only the EN post
+  - `search.json` contains both language variants
+
+## Authoring a bilingual post (for next time)
+
+1. Write the canonical post as usual (no new fields needed; `lang` defaults to `en`).
+2. Write the translation with `lang: 'vi'` and `translationOf: '<canonical-filename-without-ext>'`.
+3. Keep `date` identical on both so the pair sorts together.

--- a/data/blog/git-worktree-mot-repo-nhieu-thu-muc-lam-viec.mdx
+++ b/data/blog/git-worktree-mot-repo-nhieu-thu-muc-lam-viec.mdx
@@ -1,0 +1,154 @@
+---
+title: 'Git worktree: một repo, nhiều thư mục làm việc'
+lang: 'vi'
+translationOf: 'git-worktree-one-repo-many-working-directories'
+date: '2026-07-15'
+draft: false
+summary: 'Cách git worktree cho phép checkout nhiều nhánh cùng lúc — và vì sao nó trở thành thứ không thể thiếu khi mình muốn chạy nhiều AI coding agent song song trên một repo.'
+tags: ['git', 'git-worktree', 'git-workflows', 'ai-agents']
+authors: ['default']
+---
+
+Gần đây mình gặp một bài toán thế này: muốn chạy 2–3 việc **song song** trên cùng một project — mỗi việc giao cho một AI coding agent, mỗi agent làm trên một nhánh riêng. Nghe rất hợp lý, cho đến khi bạn nhận ra mỗi agent đều muốn `git checkout` nhánh của nó... trong cùng một thư mục. Agent B vừa checkout nhánh của mình là toàn bộ file agent A đang sửa bị đè ngay lập tức.
+
+Hoá ra Git đã giải quyết bài toán này từ nhiều năm trước, bằng một tính năng mà phần lớn dev chưa từng đụng tới: **`git worktree`**.
+
+## Git bình thường hoạt động thế nào (và vì sao có vấn đề)
+
+Khi bạn clone một repo, bạn có một thư mục như thế này:
+
+```
+myproject/
+├── .git/          ← "bộ não": toàn bộ history, branches, commits, objects
+├── src/           ← "working directory": các file bạn đang nhìn thấy & sửa
+├── package.json
+└── ...
+```
+
+Điểm mấu chốt: **`.git/` chứa TẤT CẢ các nhánh**, nhưng working directory chỉ hiển thị được **một nhánh tại một thời điểm** — chính là nhánh mà `HEAD` đang trỏ tới.
+
+Khi bạn chạy `git checkout feat/task-b`, Git không "chuyển bạn sang chỗ khác" — nó **viết đè** các file trong working directory bằng snapshot của nhánh `feat/task-b`. Đây chính là lý do 2 agent (hay 2 phiên bản của chính bạn) không thể làm 2 nhánh cùng lúc trong 1 thư mục:
+
+```
+                 .git/  (chứa cả feat/a lẫn fix/b)
+                   |
+                   v
+        working directory  ← chỉ show được 1 nhánh
+                   ^
+        Agent A đang sửa feat/a
+        Agent B checkout fix/b  →  bùm, file của A bị đè
+```
+
+## Git worktree: một bộ não, nhiều bàn làm việc
+
+Ý tưởng cực kỳ đơn giản: **một bộ não `.git`, nhiều working directory**. Mỗi working directory checkout một nhánh riêng.
+
+```bash
+# Đang đứng ở myproject/ (nhánh main)
+git worktree add ../myproject--feat-a feat/task-a
+git worktree add ../myproject--fix-b  fix/task-b
+```
+
+Kết quả trên ổ đĩa:
+
+```
+myproject/            ← worktree "chính", đang ở main
+├── .git/             ← bộ não DUY NHẤT, dùng chung
+└── src/...
+
+myproject--feat-a/    ← worktree phụ, đang ở feat/task-a
+├── .git              ← chú ý: đây là 1 FILE, không phải folder!
+└── src/...
+
+myproject--fix-b/     ← worktree phụ, đang ở fix/task-b
+├── .git              ← cũng là file
+└── src/...
+```
+
+## Bên trong nó hoạt động ra sao?
+
+Đây là phần hay nhất. **File** `.git` trong worktree phụ chỉ chứa đúng một dòng:
+
+```
+gitdir: /Users/you/myproject/.git/worktrees/myproject--feat-a
+```
+
+Nó là một **con trỏ** chỉ ngược về repo chính. Luồng hoạt động khi bạn chạy lệnh Git trong worktree phụ:
+
+```
+1. Bạn chạy `git commit` trong myproject--feat-a/
+        |
+        v
+2. Git đọc file .git → thấy "gitdir: ..." → biết bộ não thật nằm ở đâu
+        |
+        v
+3. Git dùng HEAD RIÊNG của worktree này
+   (lưu tại .git/worktrees/myproject--feat-a/HEAD)
+        |
+        v
+4. Commit được ghi vào object database CHUNG (.git/objects)
+        |
+        v
+5. Mọi worktree khác NHÌN THẤY commit này ngay lập tức
+   (không cần push/pull gì cả — vì chung một bộ não)
+```
+
+Nói cách khác: mỗi worktree có **HEAD riêng, index (staging area) riêng, working files riêng** — nhưng **commits, branches, history, stash objects đều dùng chung**. Commit ở worktree A, sang worktree B chạy `git log feat/task-a` là thấy liền.
+
+Một cách hình dung mà mình rất thích: `.git` là **một tủ hồ sơ trung tâm**, còn mỗi worktree là **một bàn làm việc**. Ba người ngồi ba bàn, mỗi bàn trải một bộ hồ sơ khác nhau ra làm — nhưng làm xong đều cất về cùng một tủ.
+
+## Những lệnh thực sự cần dùng
+
+```bash
+# Tạo worktree, checkout một nhánh có sẵn
+git worktree add ../myproject--feat-a feat/task-a
+
+# Tạo worktree + tạo nhánh mới trong một lệnh (mình dùng cái này nhiều nhất)
+git worktree add -b feat/task-c ../myproject--feat-c main
+
+# Xem danh sách các worktree
+git worktree list
+# /Users/you/myproject           abc1234 [main]
+# /Users/you/myproject--feat-a   def5678 [feat/task-a]
+
+# Xoá worktree khi xong việc (NHÁNH vẫn còn, chỉ mất thư mục)
+git worktree remove ../myproject--feat-a
+
+# Dọn metadata nếu lỡ rm -rf thư mục bằng tay
+git worktree prune
+```
+
+## Thành quả: chạy AI agent song song trên một repo
+
+Quay lại bài toán ban đầu. Với worktree, chạy nhiều coding agent song song trở nên đơn giản đến bất ngờ:
+
+```bash
+git worktree add -b feat/task-a ../myproject--feat-a main
+git worktree add -b fix/task-b  ../myproject--fix-b  main
+```
+
+Rồi mở một agent session (Claude Code, Cursor, tool nào bạn dùng cũng được) **cho mỗi worktree**. Mỗi agent:
+
+- làm việc trong thư mục riêng — không đè file của nhau,
+- commit vào nhánh riêng — không tranh nhau HEAD,
+- và mọi thứ đều nằm trong cùng một repo — nên review, merge, mở PR như bình thường.
+
+Một số tool còn tự động hoá luôn bước này: Claude Code chẳng hạn, có thể spawn subagent với worktree isolation — nó tự tạo worktree tạm cho mỗi agent và tự dọn nếu không có thay đổi gì.
+
+Xong việc nào: merge hoặc mở PR từ nhánh đó, rồi `git worktree remove` thư mục. Gọn.
+
+## Mấy cái dễ vấp (gotchas)
+
+- **Một nhánh chỉ được checkout ở MỘT worktree tại một thời điểm.** Nếu `main` đang mở ở worktree chính, lệnh `git worktree add ... main` sẽ fail ngay. Đây là feature chứ không phải bug — hai thư mục cùng sửa một nhánh sẽ làm loạn HEAD của nhau.
+- **Chỉ những gì Git quản lý mới được chia sẻ.** `node_modules/`, `.env`, build cache — mọi thứ ignored hoặc untracked đều nằm ngoài Git, nên mỗi worktree phải tự `npm install`, tự copy (hoặc symlink) `.env`. Đây là chi phí ẩn lớn nhất với project JS.
+- **Xoá bằng `git worktree remove`**, đừng `rm -rf` tay. Lỡ xoá tay rồi thì chạy `git worktree prune` để Git dọn metadata còn sót.
+- **Worktree ≠ clone.** Clone là copy cả bộ não — tốn disk hơn, history tách rời, phải push/pull để sync. Worktree dùng chung một bộ não: nhẹ hơn nhiều, và commit thấy nhau ngay lập tức.
+- Push, pull, mở PR từ worktree nào cũng bình thường — remote config cũng dùng chung.
+
+## Tóm lại
+
+- **Một `.git`, nhiều bàn làm việc** — mỗi worktree là một thư mục độc lập với HEAD và nhánh riêng, nhưng chung toàn bộ history.
+- Đây là lời giải gọn gàng cho bài toán "N agent (hay N việc) song song trên một repo": mỗi việc một worktree + một nhánh, không ai đè file của ai.
+- Nhớ chi phí ẩn: dependencies và file ignored phải setup lại cho từng worktree.
+
+Nếu bạn vẫn đang vật lộn với combo `git stash` + `checkout` mỗi lần có việc gấp chen ngang — thử worktree đi. Đống thay đổi dở dang của bạn vẫn nằm nguyên chỗ cũ, trên chiếc bàn riêng của nó.

--- a/data/blog/git-worktree-one-repo-many-working-directories.mdx
+++ b/data/blog/git-worktree-one-repo-many-working-directories.mdx
@@ -1,0 +1,153 @@
+---
+title: 'Git worktree: one repo, many working directories'
+lang: 'en'
+date: '2026-07-15'
+draft: false
+summary: 'How git worktree lets you check out multiple branches at the same time — and why it became essential the day I wanted several AI coding agents working on one repo in parallel.'
+tags: ['git', 'git-worktree', 'git-workflows', 'ai-agents']
+authors: ['default']
+---
+
+Here's a problem I ran into recently: I wanted to run 2–3 tasks **in parallel** on the same project — each task handled by its own AI coding agent, each on its own branch. Sounds reasonable, until you realize that every agent wants to `git checkout` its own branch... in the same directory. The moment agent B checks out its branch, it wipes out the files agent A is editing.
+
+Turns out Git solved this problem years ago with a feature most developers never touch: **`git worktree`**.
+
+## How normal Git works (and why the problem exists)
+
+When you clone a repo, you get a directory like this:
+
+```
+myproject/
+├── .git/          ← the "brain": all history, branches, commits, objects
+├── src/           ← the "working directory": the files you see & edit
+├── package.json
+└── ...
+```
+
+The key insight: **`.git/` contains ALL branches**, but the working directory can only show **one branch at a time** — whichever one `HEAD` points to.
+
+When you run `git checkout feat/task-b`, Git doesn't "move you somewhere else" — it **overwrites** the files in your working directory with the snapshot of `feat/task-b`. That's exactly why two agents (or two of you) can't work on two branches in one directory:
+
+```
+                 .git/  (contains both feat/a and fix/b)
+                   |
+                   v
+        working directory  ← can only show 1 branch
+                   ^
+        Agent A is editing feat/a
+        Agent B checks out fix/b  →  boom, A's files get overwritten
+```
+
+## Enter git worktree: one brain, many desks
+
+The idea is dead simple: **one `.git` brain, multiple working directories**. Each working directory has its own branch checked out.
+
+```bash
+# Standing in myproject/ (on main)
+git worktree add ../myproject--feat-a feat/task-a
+git worktree add ../myproject--fix-b  fix/task-b
+```
+
+What you get on disk:
+
+```
+myproject/            ← the "main" worktree, on main
+├── .git/             ← the ONE and only brain, shared
+└── src/...
+
+myproject--feat-a/    ← linked worktree, on feat/task-a
+├── .git              ← note: this is a FILE, not a folder!
+└── src/...
+
+myproject--fix-b/     ← linked worktree, on fix/task-b
+├── .git              ← also a file
+└── src/...
+```
+
+## How it works under the hood
+
+This is the best part. The `.git` **file** in a linked worktree contains exactly one line:
+
+```
+gitdir: /Users/you/myproject/.git/worktrees/myproject--feat-a
+```
+
+It's a **pointer** back to the main repo. Here's what happens when you run a Git command inside a linked worktree:
+
+```
+1. You run `git commit` inside myproject--feat-a/
+        |
+        v
+2. Git reads the .git file → sees "gitdir: ..." → knows where the real brain is
+        |
+        v
+3. Git uses this worktree's OWN HEAD
+   (stored at .git/worktrees/myproject--feat-a/HEAD)
+        |
+        v
+4. The commit is written to the SHARED object database (.git/objects)
+        |
+        v
+5. Every other worktree sees that commit immediately
+   (no push/pull needed — it's the same brain)
+```
+
+In other words: each worktree gets its **own HEAD, its own index (staging area), and its own working files** — but **commits, branches, history, and stash objects are all shared**. Commit in worktree A, then run `git log feat/task-a` in worktree B — it's right there.
+
+A mental model that stuck with me: `.git` is a **central filing cabinet**, and each worktree is a **desk**. Three people sit at three desks, each with a different folder of documents spread out — but everything gets filed back into the same cabinet.
+
+## The commands you actually need
+
+```bash
+# Create a worktree, checking out an existing branch
+git worktree add ../myproject--feat-a feat/task-a
+
+# Create a worktree AND a new branch in one go (the one I use most)
+git worktree add -b feat/task-c ../myproject--feat-c main
+
+# List all worktrees
+git worktree list
+# /Users/you/myproject           abc1234 [main]
+# /Users/you/myproject--feat-a   def5678 [feat/task-a]
+
+# Remove a worktree when done (the BRANCH survives, only the folder goes)
+git worktree remove ../myproject--feat-a
+
+# Clean up metadata if you rm -rf'ed a worktree by hand
+git worktree prune
+```
+
+## The payoff: parallel AI agents on one repo
+
+Back to the original problem. With worktrees, running multiple coding agents in parallel becomes trivial:
+
+```bash
+git worktree add -b feat/task-a ../myproject--feat-a main
+git worktree add -b fix/task-b  ../myproject--fix-b  main
+```
+
+Then open one agent session (Claude Code, Cursor, whatever you use) **per worktree**. Each agent:
+
+- works in its own directory — no file collisions,
+- commits to its own branch — no HEAD fights,
+- and everything lands in the same repo — so you review, merge, and open PRs as usual.
+
+Some tools even automate this: Claude Code, for instance, can spawn subagents with worktree isolation — it creates a temporary worktree per agent and cleans it up automatically if nothing changed.
+
+When a task is done: merge or open a PR from its branch, then `git worktree remove` the folder. Done.
+
+## Gotchas worth knowing
+
+- **A branch can only be checked out in ONE worktree at a time.** If `main` is open in your main worktree, `git worktree add ... main` fails immediately. This is a feature, not a bug — two directories editing one branch would corrupt each other's HEAD.
+- **Only Git-tracked files are shared.** `node_modules/`, `.env`, build caches — anything ignored or untracked lives outside Git, so every worktree needs its own `npm install` and its own copy (or symlink) of `.env`. This is the biggest hidden cost for JS projects.
+- **Remove with `git worktree remove`**, not `rm -rf`. If you already deleted it by hand, run `git worktree prune` to clean up the leftover metadata.
+- **Worktree ≠ clone.** A clone copies the whole brain — more disk, separate history, and you need push/pull to sync. Worktrees share one brain: lighter, and commits are visible across worktrees instantly.
+- Push, pull, and PRs work normally from any worktree — the remote config is shared too.
+
+## Wrap-up
+
+- **One `.git`, many desks** — each worktree is an independent directory with its own HEAD and branch, sharing all history.
+- It's the clean answer to "N agents (or N tasks) in parallel on one repo": one worktree + one branch per task, nobody overwrites anybody.
+- Remember the hidden cost: dependencies and ignored files must be set up per worktree.
+
+If you've been juggling `git stash` + `checkout` every time something urgent interrupts your feature work — try a worktree instead. Your half-finished changes stay exactly where you left them, on their own desk.

--- a/data/misc/dropshipping-la-gi.mdx
+++ b/data/misc/dropshipping-la-gi.mdx
@@ -11,31 +11,31 @@ tags: ['dropshipping', 'ecommerce', 'business']
 
 Dropship (hay đầy đủ là **Dropshipping**) hiểu một cách đơn giản nhất là **"bán hàng bỏ qua khâu vận chuyển và kho bãi"**.
 
-Anh đóng vai trò là người bán lẻ, nhưng anh **không cần bỏ vốn mua sẵn hàng về lưu kho**, cũng không cần tự đóng gói hay mang ra bưu cục gửi cho khách.
+Bạn đóng vai trò là người bán lẻ, nhưng bạn **không cần bỏ vốn mua sẵn hàng về lưu kho**, cũng không cần tự đóng gói hay mang ra bưu cục gửi cho khách.
 
 ---
 
 ### Mô hình này hoạt động thế nào?
 
-Để anh dễ hình dung, quy trình của nó chỉ gói gọn trong 4 bước như thế này thôi:
+Để dễ hình dung, quy trình của nó chỉ gói gọn trong 4 bước như thế này thôi:
 
 ```
-[Khách mua hàng trên web của anh]
+[Khách mua hàng trên web của bạn]
        │ ($100)
        ▼
-[Anh bỏ túi tiền lời] ◄─── (Giữ lại $40)
+[Bạn bỏ túi tiền lời] ◄─── (Giữ lại $40)
        │
        ▼ ($60)
-[Anh gửi đơn + tiền gốc cho Nhà cung cấp]
+[Bạn gửi đơn + tiền gốc cho Nhà cung cấp]
        │
        ▼
 [Nhà cung cấp đóng gói & tự ship thẳng tới tay Khách]
 ```
 
-1. **Đăng bán:** Anh tìm một nguồn hàng có giá sỉ tốt (ví dụ: cái ốp lưng giá gốc $5). Anh lấy hình ảnh, thông tin sản phẩm đó đem đăng lên website của mình hoặc các sàn thương mại điện tử với giá bán lẻ (ví dụ: $15).
-2. **Khách đặt hàng:** Có người vào cửa hàng của anh mua cái ốp lưng đó và trả cho anh $15.
-3. **Mua hàng gốc:** Anh dùng tiền khách vừa trả, quay lại bên nhà cung cấp đặt đúng sản phẩm đó với giá gốc $5 và điền địa chỉ giao hàng là **địa chỉ của khách**.
-4. **Vận chuyển:** Nhà cung cấp tự đóng gói sản phẩm (thường dưới tên thương hiệu của anh) và ship thẳng đến tay người mua. Anh bỏ túi phần chênh lệch là $10.
+1. **Đăng bán:** Bạn tìm một nguồn hàng có giá sỉ tốt (ví dụ: cái ốp lưng giá gốc $5). Bạn lấy hình ảnh, thông tin sản phẩm đó đem đăng lên website của mình hoặc các sàn thương mại điện tử với giá bán lẻ (ví dụ: $15).
+2. **Khách đặt hàng:** Có người vào cửa hàng của bạn mua cái ốp lưng đó và trả cho bạn $15.
+3. **Mua hàng gốc:** Bạn dùng tiền khách vừa trả, quay lại bên nhà cung cấp đặt đúng sản phẩm đó với giá gốc $5 và điền địa chỉ giao hàng là **địa chỉ của khách**.
+4. **Vận chuyển:** Nhà cung cấp tự đóng gói sản phẩm (thường dưới tên thương hiệu của bạn) và ship thẳng đến tay người mua. Bạn bỏ túi phần chênh lệch là $10.
 
 ---
 
@@ -45,13 +45,13 @@ Nghề này nghe thì rất "màu hồng" nhưng thực tế nó luôn có hai m
 
 **Điểm cộng:**
 
-- **Vốn cực mỏng:** Anh không sợ bị chôn vốn vào hàng tồn kho. Có khách mua thì anh mới bỏ tiền ra lấy hàng.
-- **Làm việc linh hoạt:** Chỉ cần một chiếc laptop và kết nối mạng là anh vận hành được, ngồi ở Hà Nội vẫn bán được hàng cho khách ở Mỹ, châu Âu.
-- **Dễ thử nghiệm:** Hôm nay anh thích bán ốp lưng, ngày mai thấy thị trường chuộng máy massage mini thì đổi qua bán máy massage trong vài cú click chuột, không lo lỗ tiền ôm hàng.
+- **Vốn cực mỏng:** Bạn không sợ bị chôn vốn vào hàng tồn kho. Có khách mua thì bạn mới bỏ tiền ra lấy hàng.
+- **Làm việc linh hoạt:** Chỉ cần một chiếc laptop và kết nối mạng là bạn vận hành được, ngồi ở Hà Nội vẫn bán được hàng cho khách ở Mỹ, châu Âu.
+- **Dễ thử nghiệm:** Hôm nay bạn thích bán ốp lưng, ngày mai thấy thị trường chuộng máy massage mini thì đổi qua bán máy massage trong vài cú click chuột, không lo lỗ tiền ôm hàng.
 
 **Điểm trừ (cái bẫy của người mới):**
 
-- **Cạnh tranh rất khốc liệt:** Vì ai cũng làm được nên biên lợi nhuận (margin) ngày càng mỏng. Anh sẽ phải đổ nhiều tiền và chất xám vào **marketing/chạy quảng cáo** để kéo khách.
-- **Không kiểm soát được chất lượng & vận chuyển:** Nếu nhà cung cấp giao chậm, giao sai màu hoặc hàng bị lỗi, anh sẽ là người đứng ra "hứng gạch" từ khách hàng và chịu tiền hoàn (refund).
+- **Cạnh tranh rất khốc liệt:** Vì ai cũng làm được nên biên lợi nhuận (margin) ngày càng mỏng. Bạn sẽ phải đổ nhiều tiền và chất xám vào **marketing/chạy quảng cáo** để kéo khách.
+- **Không kiểm soát được chất lượng & vận chuyển:** Nếu nhà cung cấp giao chậm, giao sai màu hoặc hàng bị lỗi, bạn sẽ là người đứng ra "hứng gạch" từ khách hàng và chịu tiền hoàn (refund).
 
-Tóm lại, làm dropship thực chất là anh đang làm **chuyên gia marketing và chăm sóc khách hàng**, mượn kho bãi và sản phẩm của người khác để kiếm tiền chênh lệch.
+Tóm lại, làm dropship thực chất là bạn đang làm **chuyên gia marketing và chăm sóc khách hàng**, mượn kho bãi và sản phẩm của người khác để kiếm tiền chênh lệch.

--- a/src/components/studio/StudioShell.astro
+++ b/src/components/studio/StudioShell.astro
@@ -30,9 +30,9 @@ const [posts, snippets, miscNotes] = await Promise.all([
   getCollection('snippets', isPublished),
   getCollection('misc', isPublished),
 ])
-const latestPost = posts.sort(
-  (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
-)[0]
+const latestPost = posts
+  .filter((p) => !p.data.translationOf)
+  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())[0]
 const latestSnippet = snippets.sort((a, b) => b.id.localeCompare(a.id))[0]
 const latestMisc = miscNotes.sort(
   (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -36,6 +36,11 @@ const blog = defineCollection({
   loader: glob({ pattern: '**/*.mdx', base: './data/blog' }),
   schema: z.object({
     title: z.string(),
+    lang: z.enum(['en', 'vi']).default('en'),
+    // Id of the primary-language post this is a translation of. Unset on the
+    // canonical post; lists (index, home, feed, tags) show only posts where
+    // this is unset — translations are reachable via the language switcher.
+    translationOf: z.string().optional(),
     ...sharedFields,
   }),
 })

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -17,6 +17,16 @@ export function isPublished<T extends Draftable>(entry: T): boolean {
   return entry.data.draft !== true
 }
 
+type Translatable = { data: { translationOf?: string } }
+
+/**
+ * Primary-language entries only — lists (index, home, feed, tags) show these;
+ * translations are reachable via the language switcher on the detail page.
+ */
+export function isPrimary<T extends Translatable>(entry: T): boolean {
+  return !entry.data.translationOf
+}
+
 function byDateDesc(
   a: { data: { date: Date } },
   b: { data: { date: Date } },
@@ -54,7 +64,7 @@ export async function getTagCounts(): Promise<Record<string, number>> {
     getPublishedSnippets(),
   ])
   const counts: Record<string, number> = {}
-  for (const entry of [...posts, ...snippets]) {
+  for (const entry of [...posts.filter(isPrimary), ...snippets]) {
     for (const tag of entry.data.tags) {
       const s = ghSlug(tag)
       counts[s] = (counts[s] ?? 0) + 1
@@ -72,7 +82,7 @@ export async function getContentByTag(tag: string) {
   const hasTag = (entry: { data: { tags: string[] } }) =>
     entry.data.tags.map((t) => ghSlug(t)).includes(tag)
   return {
-    posts: posts.filter(hasTag),
+    posts: posts.filter(isPrimary).filter(hasTag),
     snippets: snippets.filter(hasTag),
   }
 }

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -15,12 +15,20 @@ import BaseLayout from '~/layouts/BaseLayout.astro'
 // Slug parity: id = filename (no nested dirs) → `/blog/<slug>` exactly as legacy.
 export async function getStaticPaths() {
   const posts = await getCollection('blog', isPublished)
-  return posts.map((post) => ({ params: { slug: post.id }, props: { post } }))
+  return posts.map((post) => {
+    const primaryId = post.data.translationOf ?? post.id
+    // Every language variant of the same post: the primary + anything that
+    // points back to it via `translationOf`.
+    const translations = posts
+      .filter((p) => p.id === primaryId || p.data.translationOf === primaryId)
+      .sort((a, b) => a.data.lang.localeCompare(b.data.lang))
+    return { params: { slug: post.id }, props: { post, translations } }
+  })
 }
 
-const { post } = Astro.props
+const { post, translations } = Astro.props
 const { Content } = await render(post)
-const { title, summary, seoTitle, seoDescription, date, lastmod, tags, images, canonicalUrl } =
+const { title, summary, seoTitle, seoDescription, date, lastmod, tags, images, canonicalUrl, lang } =
   post.data
 const metaTitle = seoTitle ?? title
 const metaDescription = seoDescription ?? summary
@@ -42,7 +50,7 @@ const jsonLd = [
     datePublished: date.toISOString(),
     dateModified: lastmod ? new Date(lastmod).toISOString() : undefined,
     keywords: tags,
-    inLanguage: 'en',
+    inLanguage: lang,
   }),
   breadcrumbJsonLd([
     { name: 'Home', url: SITE.siteUrl },
@@ -50,6 +58,26 @@ const jsonLd = [
     { name: title, url: canonical },
   ]),
 ]
+
+// hreflang alternates so search engines know these pages are translations
+// of each other, not unrelated/duplicate content. `x-default` falls back to
+// the primary (non-translated) post.
+const alternates =
+  translations.length > 1
+    ? [
+        ...translations.map((t) => ({
+          hreflang: t.data.lang,
+          href: new URL(`/blog/${t.id}`, SITE.siteUrl).href,
+        })),
+        {
+          hreflang: 'x-default',
+          href: new URL(
+            `/blog/${translations.find((t) => !t.data.translationOf)?.id ?? post.id}`,
+            SITE.siteUrl,
+          ).href,
+        },
+      ]
+    : []
 ---
 
 <BaseLayout
@@ -60,6 +88,8 @@ const jsonLd = [
   ogType="article"
   publishedTime={date.toISOString()}
   modifiedTime={lastmod ? new Date(lastmod).toISOString() : undefined}
+  lang={lang}
+  alternates={alternates}
 >
   <Fragment slot="head">
     {jsonLd.map((data) => <JsonLd data={data} />)}
@@ -85,6 +115,26 @@ const jsonLd = [
               #{tag}
             </a>
           ))
+        }
+        {
+          translations.length > 1 && (
+            <span class="ml-auto flex items-center gap-0.5 rounded-full border border-line bg-panel2 p-0.5">
+              {translations.map((t) =>
+                t.id === post.id ? (
+                  <span class="rounded-full bg-ink px-2.5 py-1 uppercase tracking-wide text-bg">
+                    {t.data.lang}
+                  </span>
+                ) : (
+                  <a
+                    href={`/blog/${t.id}`}
+                    class="rounded-full px-2.5 py-1 uppercase tracking-wide text-muted no-underline transition-colors hover:text-ink"
+                  >
+                    {t.data.lang}
+                  </a>
+                ),
+              )}
+            </span>
+          )
         }
       </div>
       <Content components={{ Twemoji }} />

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -2,11 +2,13 @@
 import PageHeader from '~/components/PageHeader.astro'
 import PostList from '~/components/PostList.astro'
 import StudioShell from '~/components/studio/StudioShell.astro'
-import { getPublishedBlog } from '~/lib/content'
+import { getPublishedBlog, isPrimary } from '~/lib/content'
 import BaseLayout from '~/layouts/BaseLayout.astro'
 import { POSTS_PER_PAGE } from '~/lib/site'
 
-const posts = await getPublishedBlog()
+// Index lists primary-language posts only; translations are reachable via the
+// language switcher on the post's detail page.
+const posts = (await getPublishedBlog()).filter(isPrimary)
 const totalPages = Math.ceil(posts.length / POSTS_PER_PAGE)
 const display = posts.slice(0, POSTS_PER_PAGE)
 ---

--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -2,7 +2,7 @@
 import PageHeader from '~/components/PageHeader.astro'
 import PostList from '~/components/PostList.astro'
 import StudioShell from '~/components/studio/StudioShell.astro'
-import { getPublishedBlog } from '~/lib/content'
+import { getPublishedBlog, isPrimary } from '~/lib/content'
 import BaseLayout from '~/layouts/BaseLayout.astro'
 import { POSTS_PER_PAGE } from '~/lib/site'
 
@@ -10,7 +10,7 @@ import { POSTS_PER_PAGE } from '~/lib/site'
 // too would duplicate that page's content under a second URL, so pages start
 // at 2.
 export async function getStaticPaths() {
-  const posts = await getPublishedBlog()
+  const posts = (await getPublishedBlog()).filter(isPrimary)
   const totalPages = Math.ceil(posts.length / POSTS_PER_PAGE)
   return Array.from({ length: Math.max(0, totalPages - 1) }, (_, i) => {
     const page = i + 2

--- a/src/pages/feed.xml.ts
+++ b/src/pages/feed.xml.ts
@@ -1,6 +1,10 @@
 import rss from '@astrojs/rss'
 import type { APIContext } from 'astro'
-import { getPublishedBlog, getPublishedSnippets } from '~/lib/content'
+import {
+  getPublishedBlog,
+  getPublishedSnippets,
+  isPrimary,
+} from '~/lib/content'
 import { SITE } from '~/lib/site'
 
 /**
@@ -15,7 +19,9 @@ export async function GET(context: APIContext) {
   ])
 
   const items = [
-    ...posts.map((p) => ({ entry: p, link: `/blog/${p.id}` })),
+    ...posts
+      .filter(isPrimary)
+      .map((p) => ({ entry: p, link: `/blog/${p.id}` })),
     ...snippets.map((s) => ({ entry: s, link: `/gists/${s.id}` })),
   ].sort((a, b) => b.entry.data.date.valueOf() - a.entry.data.date.valueOf())
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,9 +11,9 @@ import { siteJsonLd } from '~/lib/seo'
 
 const isPublished = (d: { data: { draft?: boolean } }) => d.data.draft !== true
 
-const posts = (await getCollection('blog', isPublished)).sort(
-  (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
-)
+const posts = (await getCollection('blog', isPublished))
+  .filter((p) => !p.data.translationOf)
+  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
 const latest = posts.slice(0, 3)
 
 const dateFmt = new Intl.DateTimeFormat('en-CA') // YYYY-MM-DD


### PR DESCRIPTION
## Summary

Ports the bilingual pattern (`lang` + `translationOf`) from the `misc` collection to the `blog` collection, so technical posts can ship in English (canonical) and Vietnamese (translation) under `/blog/<slug>`. Ships the first bilingual pair — a post on git worktree — and aligns the existing Vietnamese dropshipping note with the blog's reader-facing voice.

## Changes

- Add `lang` and `translationOf` fields to the blog collection schema (`lang` defaults to `en`, existing posts unaffected)
- List only primary-language posts on the blog index, pagination, home latest, studio sidebar, RSS feed, and topic pages via a shared `isPrimary()` helper
- Render a language switcher on the post detail page, with hreflang alternates (`en`/`vi`/`x-default`) and per-language `<html lang>` + JSON-LD `inLanguage`
- Keep both language variants searchable in `search.json`
- Add the "Git worktree: one repo, many working directories" post in English and Vietnamese
- Rewrite the Vietnamese dropshipping note in the blog's voice
- Add the SDD spec folder documenting the feature and how to author bilingual posts